### PR TITLE
Default snappy settings

### DIFF
--- a/reynolds_blender/snappy_hexmesh.py
+++ b/reynolds_blender/snappy_hexmesh.py
@@ -129,9 +129,10 @@ def generate_snappyhexmeshdict(self, context):
         snappy_dict['castellatedMeshControls']['maxLoadUnbalance'] = scene.max_load_unbalance
         snappy_dict['castellatedMeshControls']['resolveFeatureAngle'] = scene.resolve_feature_angle
         location_in_mesh = scene.location_in_mesh
-        snappy_dict['castellatedMeshControls']['locationInMesh'] = [location_in_mesh[0],
-                                                                    location_in_mesh[2],
-                                                                    location_in_mesh[1]]
+        if location_in_mesh[0] != 0 and location_in_mesh[1] != 0 and location_in_mesh[2] != 0:
+            snappy_dict['castellatedMeshControls']['locationInMesh'] = [location_in_mesh[0],
+                                                                        location_in_mesh[2],
+                                                                        location_in_mesh[1]]
         snappy_dict['castellatedMeshControls']['allowFreeStandingZoneFaces'] = scene.allow_free_standing_zones
 
         # snapControls
@@ -144,7 +145,7 @@ def generate_snappyhexmeshdict(self, context):
         snappy_dict['snapControls']['explicitFeatureSnap'] = scene.explicit_feature_snap
         snappy_dict['snapControls']['multiRegionFeatureSnap'] = scene.multi_region_feature_snap
 
-        # addLayersControls 
+        # addLayersControls
         for name, layers in scene.add_layers.items():
             snappy_dict['addLayersControls']['layers'][name] = {'nSurfaceLayers': layers}
         snappy_dict['addLayersControls']['relativeSizes'] = scene.relative_sizes
@@ -155,7 +156,7 @@ def generate_snappyhexmeshdict(self, context):
         snappy_dict['addLayersControls']['featureAngle'] = scene.layer_feature_angle
         snappy_dict['addLayersControls']['nRelaxIter'] = scene.layer_n_relax_iter
         snappy_dict['addLayersControls']['nSmoothSurfaceNormals'] = scene.layer_n_smooth_normal_iter
-        snappy_dict['addLayersControls']['nSmoothNormals'] = scene.layer_n_smooth_iter 
+        snappy_dict['addLayersControls']['nSmoothNormals'] = scene.layer_n_smooth_iter
         snappy_dict['addLayersControls']['nSmoothThickness'] = scene.smooth_layer_thickness
         snappy_dict['addLayersControls']['maxFaceThicknessRatio'] = scene.max_face_thickness_ratio
         snappy_dict['addLayersControls']['maxThicknessToMedialRatio'] = scene.max_thickness_to_medial_ratio
@@ -169,8 +170,10 @@ def generate_snappyhexmeshdict(self, context):
         snappy_dict['meshQualityControls']['maxBoundarySkewness'] = scene.max_boundary_skewness
         snappy_dict['meshQualityControls']['maxInternalFaceSkewness'] = scene.max_internal_face_skewness
         snappy_dict['meshQualityControls']['maxConcave'] = scene.max_concaveness
-        snappy_dict['meshQualityControls']['minVol'] = scene.min_pyramid_vol
-        snappy_dict['meshQualityControls']['minTetQuality'] = scene.min_tetrahedral_quality
+        if scene.min_pyramid_vol != 0:
+            snappy_dict['meshQualityControls']['minVol'] = scene.min_pyramid_vol
+        if scene.min_tetrahedral_quality != 0:
+            snappy_dict['meshQualityControls']['minTetQuality'] = scene.min_tetrahedral_quality
         snappy_dict['meshQualityControls']['minArea'] = scene.min_face_area
         snappy_dict['meshQualityControls']['minTwist'] = scene.min_face_twist
         snappy_dict['meshQualityControls']['minDeterminant'] = scene.min_cell_det

--- a/reynolds_blender/yaml/panels/castellated_mesh.yaml
+++ b/reynolds_blender/yaml/panels/castellated_mesh.yaml
@@ -3,12 +3,13 @@ attrs:
   type: Int
   name: "Max Local Cells"
   description: Max number of cells per processor during refinement
-  default: 0
+  default: 100000
  max_global_cells:
   type: Int
   name: "Max Global Cells"
   description: Overall cell limit during refinement before removal
   default: 0
+  default: 2000000
  min_refinement_cells:
   type: Int
   name: "Min Refinement Cells"
@@ -18,22 +19,23 @@ attrs:
   type: Float
   name: "Max Load Unbalance"
   description: Level of imbalance during refining
-  default: 0.0
+  default: 0.10
  n_cells_between_levels:
   type: Int
   name: Cells Between Levels
   description: Number of layers of cells between successive refinement levels
-  defaul: 0
+  defaul: 2
  resolve_feature_angle:
   type: Float
   name: Feature Angle
   description: Apply this angle to cells which see greater intersection angle
-  default: 0
+  default: 30
   subtype: ANGLE
  allow_free_standing_zones:
   type: Bool
   name: "Allow Free Standing Zones:"
   description: "Allow Free Standing Zones"
+  default: false
 
 gui:
  - box:

--- a/reynolds_blender/yaml/panels/layers.yaml
+++ b/reynolds_blender/yaml/panels/layers.yaml
@@ -3,6 +3,7 @@ attrs:
   type: Bool
   name: Relative Sizes
   description: Relative or Absoulte Sizes of  undistored size of a refined cell?
+  default: true 
  layers_list:
   type: UIList
   coll_data_prop: shmd_layers
@@ -17,22 +18,22 @@ attrs:
   type: Int
   name: Surface layers
   description: Surface layers per patch
-  default: 0
+  default: 1
  expansion_ratio:
   type: Float
   name: Expansion Ratio
   description: Expansion factor for layer mesh
-  default: 0.0
+  default: 1.0
  final_layer_thickness:
   type: Float
   name: Final Layer Thickness
   description: Thickness of final added cell layer
-  default: 0.0
+  default: 0.3
  min_layer_thickness:
   type: Float
   name: Min Thickness
   description: Min Thickness of cell layer
-  default: 0.0
+  default: 0.25
  n_grow_layers:
   type: Int
   name: Grow Layers
@@ -42,43 +43,43 @@ attrs:
   type: Float
   name: Feature Angle
   description: When not to extrude surface
-  default: 0.0
+  default: 30.0
   subtype: ANGLE
  layer_n_relax_iter:
   type: Int
   name: Relax Iterations
   description: Maximum number of snapping relaxation iterations
-  default: 0
+  default: 3
  layer_n_smooth_normal_iter:
   type: Int
   name: Smoothing Iterations of surface normals
   description: Number of smoothing iterations of surface normals
-  default: 0
+  default: 1
  layer_n_smooth_iter:
   type: Int
   name: Smoothing Iterations
   description: Number of smoothing iterations of interior mesh movement direction
-  default: 0
+  default: 3
  smooth_layer_thickness:
   type: Float
   name: Smooth layer thickness
   description: Smooth layer thickness over surface patches
-  default: 0.0
+  default: 10.0
  max_face_thickness_ratio:
   type: Float
   name: Max Face Thickness Ratio
   description: Stop layer growth on highly warped cells
-  default: 0.0
+  default: 0.5
  max_thickness_to_medial_ratio:
   type: Float
   name: Thickness to Medial Ratio
   description: Reduce layer growth
-  default: 0.0
+  default: 0.3
  min_median_axis_angle:
   type: Float
   name: Min Median Axis Angle
   description: Angle used to pick up media axis points
-  default: 0.0
+  default: 90.0
   subtype: ANGLE
  n_buffer_cells_no_extrude:
   type: Int
@@ -89,12 +90,12 @@ attrs:
   type: Int
   name: Addition Iterations
   description: Max number of layer addition iterations
-  default: 0
+  default: 50
  layer_n_mesh_quality_iter:
   type: Int
   name: Smoothing Iterations
   description: nRelaxedIter, itearations after which mesh quality controls get used
-  default: 0
+  default: 20
 
 operators:
  shmd_layers.list_action:

--- a/reynolds_blender/yaml/panels/mesh_quality.yaml
+++ b/reynolds_blender/yaml/panels/mesh_quality.yaml
@@ -14,7 +14,7 @@ attrs:
   type: Int
   name: Max Internal skewness
   description: Max internal face skewness allowed
-  default: 20
+  default: 4
  max_concaveness:
   type: Int
   name: Max concaveness
@@ -29,12 +29,12 @@ attrs:
   type: Float
   name: Min tetrahedral quality
   description: Minimum quality of tetrahedral cells from cell decomposition
-  default: 0.0
+  default: 0
  min_pyramid_vol:
   type: Float
   name: Min pyramid volume
   description: Minimum cell pyramid volume
-  default: 0.00000000000001
+  default: 0
  min_face_area:
   type: Float
   name: Min face area
@@ -44,7 +44,7 @@ attrs:
   type: Float
   name: Min face twist
   description: Minimum face twist
-  default: 0.05
+  default: 0.02
  min_cell_det:
   type: Float
   name: Min normalized cell determinant

--- a/reynolds_blender/yaml/panels/snapping.yaml
+++ b/reynolds_blender/yaml/panels/snapping.yaml
@@ -3,39 +3,42 @@ attrs:
   type: Float
   name: Tolerance
   description: Relative distance for points to be attraced by feature point/edge
-  default: 0
+  default: 4.0
  n_smooth_patch_iter:
   type: Int
   name: Patch Smoothing Iterations
   description: Patch Smoothing Iterations
-  default: 0
+  default: 3
  disp_relax_iter:
   type: Int
   name: Displacement Relaxation Iterations
   description: Displacement Relaxation Iterations
-  default: 0
+  default: 300
  snapping_relax_iter:
   type: Int
   name: Snapping Relaxation Iterations
   description: Snapping Relaxation Iterations
-  default: 0
+  default: 5
  feature_edge_snapping_iter:
   type: Int
   name: Feature Edge Snapping Iterations
   description: Feature Edge Snapping Iterations
-  default: 0
+  default: 10
  implicit_feature_snap:
   type: Bool
   name: Implicit Feature Snap
   description: Detect geometric features by sampling the surface
+  default: false
  explicit_feature_snap:
   type: Bool
   name: Explicit Feature Snap
   description: Use castellatedMeshControls::features
+  default: true
  multi_region_feature_snap:
   type: Bool
   name: MultiRegion Feature Snap
   description: Detect features between multiple surfaces
+  default: true
 
 gui:
  - box:

--- a/tests/flange/test_flange_tutorial.py
+++ b/tests/flange/test_flange_tutorial.py
@@ -75,7 +75,7 @@ class TestFlangeTutorial(TestFoamTutorial):
         self.select_case_dir('//flange')
         self.scene.convert_to_meters = 1
         self.select_vertices(blockmesh_obj, [0, 4, 5, 1, 2, 6, 7, 3])
-        self.set_number_of_cells(20, 20, 1)
+        self.set_number_of_cells(20, 20, 20)
         self.set_grading(1, 1, 1)
         self.assign_blocks()
         patches = {'patch1': ([5], 'patch'),
@@ -119,7 +119,7 @@ class TestFlangeTutorial(TestFoamTutorial):
         self.scene.geometry_type = 'searchableSphere'
         self.scene.refinement_type = 'Region'
         self.scene.refinement_mode = 'inside'
-        self.scene.ref_reg_dist = 1e-15
+        self.scene.ref_reg_dist = 1e15
         self.scene.ref_reg_level = 3
         self.scene.has_features = False
         bpy.ops.shmd_geometries.list_action('INVOKE_DEFAULT', action='ADD')
@@ -135,7 +135,7 @@ class TestFlangeTutorial(TestFoamTutorial):
                          'inside')
         self.assertEqual(self.scene.geometries['refineHole']['refinementRegion']['level'], 3)
         self.assertAlmostEqual(self.scene.geometries['refineHole']['refinementRegion']['dist'],
-                               1e-15)
+                               999999986991104.0)
 
     def _mark_location_in_space(self):
         self.scene.location_in_mesh = [-9.23149e-05, -0.0025, -0.0025]


### PR DESCRIPTION
* Use default snappy settings for scene attributes
* Update flange test
   - Output now matches with the output if this test were solved without this add-on. 👍 