### PR TITLE
Add transport properties operator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ python:
   - "3.5"
 
 before_install:
-  # temp mongodb fix
-  - sudo rm /etc/apt/sources.list.d/mongodb-3.2.list
-
   # install blender from official sources.
   - sudo apt-get install blender
 

--- a/reynolds_blender/__init__.py
+++ b/reynolds_blender/__init__.py
@@ -58,12 +58,13 @@ if "bpy" in locals():
     importlib.reload(solver)
     importlib.reload(fvschemes)
     importlib.reload(fvsolution)
+    importlib.reload(transportproperties)
 else:
     from . import (console, foam, models, sphere, add_block, block_cells,
                    block_regions, block_mesh, mesh_objs, solver, geometry,
                    snappy_steps, feature_extraction, castellated_mesh,
                    snapping, layers, mesh_quality, snappy_hexmesh, fvschemes,
-                   fvsolution, controldict)
+                   fvsolution, controldict, transportproperties)
 
 
 from reynolds_blender.gui.attrs import set_scene_attrs, del_scene_attrs
@@ -99,6 +100,7 @@ def register():
     fvschemes.register()
     fvsolution.register()
     controldict.register()
+    transportproperties.register()
 
 def unregister():
     del_scene_attrs("common_attrs.yaml")
@@ -125,6 +127,7 @@ def unregister():
     fvschemes.unregister()
     fvsolution.unregister()
     controldict.unregister()
+    transportproperties.unregister()
 
 if __name__ == '__main__':
     register()

--- a/reynolds_blender/solver.py
+++ b/reynolds_blender/solver.py
@@ -49,6 +49,7 @@ from reynolds_blender.gui.renderer import ReynoldsGUIRenderer
 from reynolds_blender.fvschemes import FVSchemesOperator
 from reynolds_blender.fvsolution import FVSolutionOperator
 from reynolds_blender.controldict import ControlDictOperator
+from reynolds_blender.transportproperties import TransportPropertiesOperator
 
 # ----------------
 # reynolds imports
@@ -133,6 +134,7 @@ class SolverPanel(Panel):
         row.operator(FVSchemesOperator.bl_idname, text='', icon='SETTINGS')
         row.operator(FVSolutionOperator.bl_idname, text='', icon='SETTINGS')
         row.operator(ControlDictOperator.bl_idname, text='', icon='SETTINGS')
+        row.operator(TransportPropertiesOperator.bl_idname, text='', icon='SETTINGS')
         gui_renderer = ReynoldsGUIRenderer(scene, layout, 'solver_panel.yaml')
         gui_renderer.render()
 

--- a/reynolds_blender/transportproperties.py
+++ b/reynolds_blender/transportproperties.py
@@ -1,0 +1,144 @@
+#------------------------------------------------------------------------------
+# Reynolds-Blender | The Blender add-on for Reynolds, an OpenFoam toolbox.
+#------------------------------------------------------------------------------
+# Copyright|
+#------------------------------------------------------------------------------
+#     Deepak Surti       (dmsurti@gmail.com)
+#     Prabhu R           (IIT Bombay, prabhu@aero.iitb.ac.in)
+#     Shivasubramanian G (IIT Bombay, sgopalak@iitb.ac.in)
+#------------------------------------------------------------------------------
+# License
+#
+#     This file is part of reynolds-blender.
+#
+#     reynolds-blender is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     reynolds-blender is distributed in the hope that it will be useful, but
+#     WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+#     Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with reynolds-blender.  If not, see <http://www.gnu.org/licenses/>.
+#------------------------------------------------------------------------------
+
+# -----------
+# bpy imports
+# -----------
+import bpy, bmesh
+from bpy.props import (StringProperty,
+                       BoolProperty,
+                       IntProperty,
+                       FloatProperty,
+                       EnumProperty,
+                       PointerProperty,
+                       IntVectorProperty,
+                       FloatVectorProperty,
+                       CollectionProperty
+                       )
+from bpy.types import (Panel,
+                       Operator,
+                       PropertyGroup,
+                       UIList
+                       )
+from bpy.path import abspath
+from mathutils import Matrix, Vector
+
+# --------------
+# python imports
+# --------------
+import operator
+import os
+
+# ------------------------
+# reynolds blender imports
+# ------------------------
+
+from reynolds_blender.gui.register import register_classes, unregister_classes
+from reynolds_blender.gui.attrs import set_scene_attrs, del_scene_attrs
+from reynolds_blender.gui.custom_operator import create_custom_operators
+from reynolds_blender.gui.renderer import ReynoldsGUIRenderer
+
+# ----------------
+# reynolds imports
+# ----------------
+from reynolds.dict.parser import ReynoldsFoamDict
+from reynolds.foam.cmd_runner import FoamCmdRunner
+
+# ------------------------------------------------------------------------
+#    operators
+# ------------------------------------------------------------------------
+
+def generate_laplacianFoam_transport(transport, scene):
+    if scene.tp_dt_scalar_elt1 != "":
+        transport['DT'][1] = scene.tp_dt_scalar_elt1
+    if scene.tp_dt_scalar_elt1 != 0:
+        transport['DT'][2] = scene.tp_dt_scalar_elt2
+
+def generate_icoFoam_transport(transport, scene):
+    if scene.tp_dt_scalar_elt1 != "":
+        transport['nu'][1] = scene.tp_dt_scalar_elt1
+    if scene.tp_dt_scalar_elt1 != 0:
+        transport['nu'][2] = scene.tp_dt_scalar_elt2
+
+# ------------------------------------------------------------------------
+#    Panel
+# ------------------------------------------------------------------------
+
+class TransportPropertiesOperator(bpy.types.Operator):
+    bl_idname = "reynolds.of_transportproperties"
+    bl_label = "TransportProperties"
+
+    @classmethod
+    def poll(cls, context):
+        return True
+
+    def execute(self, context):
+        scene = context.scene
+        print('Generate transport props for solver: ' + scene.solver_name)
+        abs_case_dir_path = bpy.path.abspath(scene.case_dir_path)
+        transport = ReynoldsFoamDict('transportProperties.foam',
+                                     solver_name=scene.solver_name)
+        if scene.solver_name == 'laplacianFoam':
+            generate_laplacianFoam_transport(transport, scene)
+        elif scene.solver_name == 'icoFoam':
+            generate_icoFoam_transport(transport, scene)
+
+        transport_file_path = os.path.join(abs_case_dir_path, "constant",
+                                           "transportProperties")
+        with open(transport_file_path, "w+") as f:
+            f.write(str(transport))
+        return {'FINISHED'}
+
+    # Return True to force redraw
+    def check(self, context):
+        return True
+
+    def invoke(self, context, event):
+        scene = context.scene
+        return context.window_manager.invoke_props_dialog(self, width=1000)
+
+    def draw(self, context):
+        layout = self.layout
+        scene = context.scene
+        gui_renderer = ReynoldsGUIRenderer(scene, layout,
+                                           'transportProperties.yaml')
+        gui_renderer.render()
+
+# ------------------------------------------------------------------------
+# register and unregister
+# ------------------------------------------------------------------------
+
+def register():
+    register_classes(__name__)
+    set_scene_attrs('transportProperties.yaml')
+
+def unregister():
+    unregister_classes(__name__)
+    del_scene_attrs('transportProperties.yaml')
+
+if __name__ == "__main__":
+    register()

--- a/reynolds_blender/yaml/panels/transportProperties.yaml
+++ b/reynolds_blender/yaml/panels/transportProperties.yaml
@@ -1,0 +1,45 @@
+attrs:
+ tp_dt_type:
+  type: Enum
+  name: "DT transport properties type"
+  description: "DT transport properties type"
+  items: 
+    -
+     - nu
+     - nu
+     - ""
+    -
+     - DT
+     - DT 
+     - ""
+ tp_dt_scalar_elt1:
+  type: String
+  name: "Transport properties scalar el1"
+  description: "Transport properties scalar el1"
+  default: ""
+  maxlen: 1024
+ tp_dt_scalar_elt2:
+  type: Float
+  name: "Transport properties scalar el1"
+  description: "Transport properties scalar el1"
+  default: 0.0
+ 
+gui:
+ - box:
+   - row: 
+     - col: 
+        - prop:
+           scene_attr: tp_dt_type
+        - separator:
+           nums: 1
+        - row:
+          - label:
+             text : Dimensioned scalar
+          - prop:
+             scene_attr: tp_dt_scalar_elt1
+          - separator:
+             nums: 1
+        - prop:
+           scene_attr: tp_dt_scalar_elt2
+        - separator:
+           nums: 1


### PR DESCRIPTION
Generate `transportProperties` in `constant` directory.

This is a quick implementation based off `transportProperites` for icoFoam and laplacianFoam solvers from cavity and flange case dirs respectively.

Full implementation should have `transportModel` and `nu0, nuinf, k, n` etc supported.