### PR TITLE
Add p, T, U time properties

### DIFF
--- a/reynolds_blender/block_mesh.py
+++ b/reynolds_blender/block_mesh.py
@@ -142,7 +142,7 @@ def generate_blockmeshdict(self, context):
     # generate bmd regions
     bmd_boundary = []
     for name, r in scene.regions.items():
-        name, patch_type, face_labels = r
+        name, patch_type, face_labels, _ = r
         bmd_boundary.append(name)
         br = {}
         br['type'] = patch_type
@@ -179,6 +179,39 @@ def generate_blockmeshdict(self, context):
     bmd_file_path = os.path.join(abs_case_dir_path, "system", "blockMeshDict")
     with open(bmd_file_path, "w") as f:
         f.write(str(block_mesh_dict))
+
+    return {'FINISHED'}
+
+def generate_time_props(self, context):
+    scene = context.scene
+    print(' Generate time properties')
+    print(scene.time_props)
+    print(scene.time_props_dimensions)
+    print(scene.time_props_internal_field)
+
+    abs_case_dir_path = bpy.path.abspath(scene.case_dir_path)
+    # Now loop through regions and generate distinct time properties in 0 dir
+    for prop in scene.time_props:
+        time_prop_dict = ReynoldsFoamDict('timeProperty.foam')
+        time_prop_dict['dimensions'] = scene.time_props_dimensions[prop]
+        time_prop_dict['internalField'] = scene.time_props_dimensions[prop]
+        patches = {}
+        for _, r in scene.regions.items():
+            name, patch_type, face_labels, time_prop_info = r
+            print(' name: ' + name + ' time prop info: ')
+            print(time_prop_info)
+            patches[name] = {}
+            if prop in time_prop_info:
+                patches[name]['type'] = time_prop_info[prop]['type']
+                v = time_prop_info[prop]['value']
+                if v != "":
+                    patches[name]['value'] = v
+        print('Patches for time props : ')
+        print(patches)
+        time_prop_dict['boundaryField'] = patches 
+        prop_file_path = os.path.join(abs_case_dir_path, "0", prop)
+        with open(prop_file_path, "w") as f:
+            f.write(str(time_prop_dict))
 
     return {'FINISHED'}
 

--- a/reynolds_blender/yaml/panels/block_mesh_panel.yaml
+++ b/reynolds_blender/yaml/panels/block_mesh_panel.yaml
@@ -18,10 +18,19 @@ operators:
   label: Run
   description: Run blockMesh command
   execute_func: run_blockmesh
+ reynolds.generate_time_props:
+  operator_type: Operator
+  class_name: BMDTimePropsOperator
+  label: Generate Time Props
+  description: Generate time props 
+  execute_func: generate_time_props
 
 gui:
  - box: 
    - row: 
      - operator: 
         id: reynolds.block_mesh_runner
+        icon: FILE_TEXT
+     - operator: 
+        id: reynolds.generate_time_props
         icon: FILE_TEXT

--- a/reynolds_blender/yaml/panels/block_regions.yaml
+++ b/reynolds_blender/yaml/panels/block_regions.yaml
@@ -1,4 +1,10 @@
 attrs:
+ time_props:
+  type: PyList
+ time_props_dimesions:
+  type: PyDict
+ time_props_internal_field:
+  type: PyDict
  regions: 
   type: PyDict
  region_name: 
@@ -60,6 +66,69 @@ attrs:
   type: UIList
   coll_data_prop: bmd_regions
   coll_data_index: bmd_rindex
+ time_prop_dimensions:
+  type: String
+  name: "Time Property dimensions"
+  description: "Time Property dimensions:"
+  default: "[ 0 0 0 0 0 0 0 ]"
+  maxlen: 1024
+ time_prop_internal_field:
+  type: String
+  name: "Time Property internal field"
+  description: "Time Property internal field:"
+  default: "uniform 0"
+  maxlen: 1024
+ time_prop_type: 
+  type: Enum
+  name: "Time Property Type:"
+  description: "Time Property Type:"
+  items: 
+    -
+     - p
+     - p
+     - ""
+    -
+     - U
+     - U
+     - ""
+    -
+     - T
+     - T
+     - ""
+ time_prop_patch_type: 
+  type: Enum
+  name: "Time Property Type:"
+  description: "Time Property Type:"
+  default: zeroGradient
+  items: 
+    -
+     - zeroGradient
+     - zeroGradient
+     - ""
+    -
+     - fixedValue
+     - fixedValue
+     - ""
+    -
+     - noSlip
+     - noSlip
+     - ""
+    -
+     - empty
+     - empty
+     - ""
+ time_prop_value:
+  type: String
+  name: "Time Property value"
+  description: "Time Property value"
+  default: ""
+  maxlen: 1024
+ time_props:
+  type: PyList
+ time_props_dimensions:
+  type: PyDict
+ time_props_internal_field:
+  type: PyDict
 
 operators:
  regions.list_action:
@@ -87,6 +156,12 @@ operators:
   label: Remove Region
   description: Remove region to the label
   execute_func: remove_region
+ reynolds.assign_time_prop:
+  operator_type: Operator
+  class_name: BMDAssignTimePropOperator
+  label: Assign Time Property (p, U, T etc)
+  description: Assign time property to the region
+  execute_func: assign_time_prop
 
 gui:
  - box: 
@@ -144,6 +219,31 @@ gui:
               scene_attr: select_right_face
          - separator: 
             nums: 1
+     - row:
+       - box:
+         - label:
+            text: Assign time properties
+         - row:
+           - label:
+              text: Dimensions
+           - prop:
+              scene_attr: time_prop_dimensions
+         - row:
+           - label:
+              text: Internal field
+           - prop:
+              scene_attr: time_prop_internal_field
+         - row:
+           - prop:
+              scene_attr: time_prop_type
+         - row:
+           - prop:
+              scene_attr: time_prop_patch_type
+         - row:
+           - prop:
+              scene_attr: time_prop_value
+         - separator: 
+            nums: 1
    - row: 
      - operator: 
         id: reynolds.assign_region
@@ -153,3 +253,6 @@ gui:
         icon: X
      - separator: 
         nums: 1
+     - operator: 
+        id: reynolds.assign_time_prop
+        icon: X


### PR DESCRIPTION
Adds operator for p, T, U properties. 

These are integrated with the regions operator as these properties are defined for a patch/region. These are now independent of the solver being used and the user can pick the properties.

Future version can add the dependency between a solver and the time properties.