### PR TITLE
Convert block cells to property group

### DIFF
--- a/reynolds_blender/block_cells.py
+++ b/reynolds_blender/block_cells.py
@@ -69,6 +69,21 @@ from reynolds.dict.parser import ReynoldsFoamDict
 from reynolds.foam.cmd_runner import FoamCmdRunner
 
 # ------------------------------------------------------------------------
+#    scene data models
+# ------------------------------------------------------------------------
+class BlockCellsPG(bpy.types.PropertyGroup):
+    convert_to_meters = bpy.props.FloatProperty(name='FloatProperty',
+                                                description='Scaling factor',
+                                                default=0.001)
+    n_cells = bpy.props.IntVectorProperty(name='Cells',
+                                          description='Number of cells',
+                                          default=[1, 1, 1])
+    n_grading = bpy.props.IntVectorProperty(name='Cell expansion ratios',
+                                            description='Cell expansion ratios',
+                                            default=[1, 1, 1],
+                                            subtype='XYZ')
+
+# ------------------------------------------------------------------------
 #    operators
 # ------------------------------------------------------------------------
 

--- a/reynolds_blender/block_mesh.py
+++ b/reynolds_blender/block_mesh.py
@@ -128,12 +128,12 @@ def generate_blockmeshdict(self, context):
     bmd_blocks = []
     bmd_blocks.append('hex')
     bmd_blocks.append([0, 1, 2, 3, 4, 5, 6, 7])
-    bmd_blocks.append([scene.n_cells[0], scene.n_cells[1],
-                        scene.n_cells[2]])
+    bmd_blocks.append([scene.block_cells_pg.n_cells[0], scene.block_cells_pg.n_cells[1],
+                        scene.block_cells_pg.n_cells[2]])
     bmd_blocks.append('simpleGrading')
-    grading_x = [[1, 1, scene.n_grading[0]]]
-    grading_y = [[1, 1, scene.n_grading[1]]]
-    grading_z = [[1, 1, scene.n_grading[2]]]
+    grading_x = [[1, 1, scene.block_cells_pg.n_grading[0]]]
+    grading_y = [[1, 1, scene.block_cells_pg.n_grading[1]]]
+    grading_z = [[1, 1, scene.block_cells_pg.n_grading[2]]]
     grading = [grading_x, grading_y, grading_z]
     bmd_blocks.append(grading)
     print(bmd_blocks)
@@ -171,7 +171,7 @@ def generate_blockmeshdict(self, context):
     block_mesh_dict['boundary'] = bmd_boundary
 
     # set convert to meters
-    block_mesh_dict['convertToMeters'] = scene.convert_to_meters
+    block_mesh_dict['convertToMeters'] = scene.block_cells_pg.convert_to_meters
 
     print("BLOCK MESH DICT")
     print(block_mesh_dict)

--- a/reynolds_blender/gui/attrs.py
+++ b/reynolds_blender/gui/attrs.py
@@ -31,13 +31,14 @@
 import bpy
 from bpy.props import (StringProperty, BoolProperty, FloatProperty, IntProperty,
                        IntVectorProperty, EnumProperty, CollectionProperty,
-                       FloatVectorProperty, IntProperty)
+                       FloatVectorProperty, IntProperty, PointerProperty)
 
 # --------------
 # python imports
 # --------------
-import yaml
 import os
+import sys
+import yaml
 
 # ------------------------
 # reynolds blender imports
@@ -111,6 +112,24 @@ def load_bool_attr(name, props):
                                  default=props.get('default', False))
     setattr(bpy.types.Scene, name, bool_property)
 
+def load_custom_attr(name, props):
+    module_name = props.get('module', None)
+    print('Importing module ' + module_name)
+    if module_name:
+        module = sys.modules[module_name]
+        print('Imported module ')
+        print(module)
+        class_name = props.get('class', None)
+        if class_name:
+            class_ = getattr(module, class_name, None)
+            if class_:
+                print('Imported class ')
+                print(class_)
+                instance = PointerProperty(type=class_)
+                print('Setting custom attr ' + name + ' with instance: ')
+                print(instance)
+                setattr(bpy.types.Scene, name, instance)
+
 def load_scene_attr(attr):
     name, props = attr
     if props['type'] == 'String':
@@ -133,6 +152,8 @@ def load_scene_attr(attr):
         load_enum_attr(name, props)
     if props['type'] == 'UIList':
         load_ui_list_attrs(name, props)
+    if props['type'] == 'Custom':
+        load_custom_attr(name, props)
 
 def set_scene_attrs(attrs_filename):
     current_dir = os.path.realpath(os.path.dirname(__file__))

--- a/reynolds_blender/gui/renderer.py
+++ b/reynolds_blender/gui/renderer.py
@@ -86,6 +86,15 @@ class ReynoldsGUIRenderer(object):
             parent.enabled = enabled
             parent.prop(self.scene, metadata['scene_attr'])
 
+        if name == 'group_prop':
+            enabled = metadata.get('enabled', True)
+            parent.enabled = enabled
+            pointer_name = metadata['pointer']
+            pointer = getattr(self.scene, pointer_name, None)
+            if pointer:
+                print('Rendering group prop ' + pointer_name)
+                parent.prop(pointer, metadata['scene_attr'])
+
         if name == 'operator':
             action = metadata.get('action', False)
             if action:

--- a/reynolds_blender/yaml/panels/block_cells.yaml
+++ b/reynolds_blender/yaml/panels/block_cells.yaml
@@ -1,28 +1,19 @@
 attrs:
- convert_to_meters:
-  type: Float
-  name: Convert to meters
-  description: Scaling factor for all vertices
-  default: 0.001
- n_cells: 
-  type: IntVector
-  name: Cells
-  description: "Number of cells in XYZ direction"
-  default: [1, 1, 1]
- n_grading: 
-  type: IntVector
-  name: "Cell expansion ratios"
-  description: "Cell expansion ratios"
-  default: [1, 1, 1]
-  subtype: XYZ
+ block_cells_pg:
+  type: Custom
+  module: reynolds_blender.block_cells
+  class: BlockCellsPG
 
 gui:
  - box: 
    - label:
       text: Convert to meters
-   - prop: 
+   - group_prop: 
+      pointer: block_cells_pg
       scene_attr: convert_to_meters
-   - prop: 
+   - group_prop: 
+      pointer: block_cells_pg
       scene_attr: n_cells
-   - prop: 
+   - group_prop: 
+      pointer: block_cells_pg
       scene_attr: n_grading

--- a/tests/cavity/test_cavity_tutorial.py
+++ b/tests/cavity/test_cavity_tutorial.py
@@ -119,7 +119,7 @@ class TestCavityTutorial(TestFoamTutorial):
         # -------------------
         # Steps to solve case
         # -------------------
-        self.scene.convert_to_meters = 0.1
+        self.scene.block_cells_pg.convert_to_meters = 0.1
         self.set_number_of_cells(20, 20, 1)
         self.set_grading(1, 1, 1)
         # -------------------

--- a/tests/flange/test_flange_tutorial.py
+++ b/tests/flange/test_flange_tutorial.py
@@ -71,7 +71,7 @@ class TestFlangeTutorial(TestFoamTutorial):
         self.assertIsNotNone(self.scene.objects['Cube'])
         blockmesh_obj = self.scene.objects['Cube']
         bpy.ops.object.select_all(False)
-        self.scene.convert_to_meters = 1
+        self.scene.block_cells_pg.convert_to_meters = 1
         self.set_number_of_cells(20, 20, 20)
         self.set_grading(1, 1, 1)
         patches = {'patch1': (['Back'], 'patch', {'T': {'type': 'zeroGradient'}}),

--- a/tests/foam_test_case.py
+++ b/tests/foam_test_case.py
@@ -76,14 +76,14 @@ class TestFoamTutorial(unittest.TestCase):
         bpy.ops.reynolds.solve_case()
 
     def set_number_of_cells(self, x, y, z):
-        self.scene.n_cells[0] = x
-        self.scene.n_cells[1] = y
-        self.scene.n_cells[2] = z
+        self.scene.block_cells_pg.n_cells[0] = x
+        self.scene.block_cells_pg.n_cells[1] = y
+        self.scene.block_cells_pg.n_cells[2] = z
 
     def set_grading(self, x, y, z):
-        self.scene.n_grading[0] = x
-        self.scene.n_grading[1] = y
-        self.scene.n_grading[2] = z
+        self.scene.block_cells_pg.n_grading[0] = x
+        self.scene.block_cells_pg.n_grading[1] = y
+        self.scene.block_cells_pg.n_grading[2] = z
 
     def select_boundary(self, obj, patches):
         for name, (faces, patch_type, time_prop_info) in patches.items():


### PR DESCRIPTION
SUCCESS

First refactor to convert group of related scene attributes into property group with dynamic registering of the group using `PointerProperty` and rendering of the attributes in the property group.